### PR TITLE
Add authorization headers for calls to logout() and createEmbedUrlAsMe()

### DIFF
--- a/lib/Api/ApiAuthApi.php
+++ b/lib/Api/ApiAuthApi.php
@@ -903,8 +903,15 @@ class ApiAuthApi
             $defaultHeaders['User-Agent'] = $this->config->getUserAgent();
         }
 
+        $authHeaders = [];
+        $access_token = $this->config->getAccessToken();
+        if ($access_token) {
+            $authHeaders['Authorization'] = 'Bearer ' . $access_token;
+        }
+
         $headers = array_merge(
             $defaultHeaders,
+            $authHeaders,
             $headerParams,
             $headers
         );

--- a/lib/Api/AuthApi.php
+++ b/lib/Api/AuthApi.php
@@ -2112,8 +2112,15 @@ class AuthApi
             $defaultHeaders['User-Agent'] = $this->config->getUserAgent();
         }
 
+        $authHeaders = [];
+        $access_token = $this->config->getAccessToken();
+        if ($access_token) {
+            $authHeaders['Authorization'] = 'Bearer ' . $access_token;
+        }
+
         $headers = array_merge(
             $defaultHeaders,
+            $authHeaders,
             $headerParams,
             $headers
         );


### PR DESCRIPTION
Doing some spring cleaning on my github, and noticed this fix I had to put in for this API. I remember needing it because auth headers were required for these functions.

Feel free to ignore if it is not wanted for any reason or if this project is deprecated.
